### PR TITLE
PYMT-1055: Removed 'statement_description' from SDK

### DIFF
--- a/src/Endpoints/Transaction.php
+++ b/src/Endpoints/Transaction.php
@@ -22,7 +22,6 @@ use LoyaltyCorp\SdkBlueprint\Sdk\Entity;
  * @method PaymentSource|null getPaymentSource()
  * @method mixed[]|null getResponse()
  * @method mixed|null getSecurity()
- * @method string|null getStatementDescription()
  * @method string|null getStatus()
  * @method string|null getTransactionId()
  * @method string|null getUpdatedAt()

--- a/src/Traits/TransactionTrait.php
+++ b/src/Traits/TransactionTrait.php
@@ -122,15 +122,6 @@ trait TransactionTrait
     protected $security;
 
     /**
-     * Transaction statement description.
-     *
-     * @Groups({"create", "delete", "get", "list", "update"})
-     *
-     * @var string|null
-     */
-    protected $statementDescription;
-
-    /**
      * Transaction status.
      *
      * @var string|null

--- a/tests/TestCases/TransactionTestCase.php
+++ b/tests/TestCases/TransactionTestCase.php
@@ -42,7 +42,6 @@ class TransactionTestCase extends TestCase
                 'pan' => '2...H6A3',
                 'type' => 'ewallet'
             ],
-            'statementDescription' => 'PAYMENT GATEWAY',
             'user' => new User([
                 'email' => 'user@email.test'
             ])


### PR DESCRIPTION
This PR removes `statement_description` from the SDK as it is no longer required.