### PR TITLE
PYMT-1177 Updated test to assert metadata deserialisation.

### DIFF
--- a/tests/Endpoints/Transactions/PrimaryTransactionsTest.php
+++ b/tests/Endpoints/Transactions/PrimaryTransactionsTest.php
@@ -140,6 +140,10 @@ class PrimaryTransactionsTest extends TransactionTestCase
     {
         $data = $this->createResponse([
             'action' => Transaction::ACTION_DEBIT,
+            'metadata' => [
+                'ping0' => 'pong0',
+                'ping1' => 'pong1'
+            ],
             'paymentSource' => [
                 'token' => \mb_strtoupper($this->generateId()),
                 'type' => 'bank_account'


### PR DESCRIPTION
Added assertion to make sure transaction metadata returns as key => value and not deserialised entity.

Ticket: [https://loyaltycorp.atlassian.net/browse/PYMT-1177](https://loyaltycorp.atlassian.net/browse/PYMT-1177)