### PR TITLE
PYMT-1161: Added @todo comment for parser test

### DIFF
--- a/tests/Services/Webhooks/ParserTest.php
+++ b/tests/Services/Webhooks/ParserTest.php
@@ -97,6 +97,8 @@ JSON
 
         $result = $parser->parseRequest($targetClass, $request);
 
+        // @todo: SerializerFactory and Seralizer need to be stubbed so that we can assert the parser result.
+        // @see: https://loyaltycorp.atlassian.net/browse/PYMT-1222
         self::assertNotNull($result);
     }
 


### PR DESCRIPTION
As simple as the title states. Added a @todo pointing to a Jira task for a test so that it is not forgotten.