### PR TITLE
PYMT-1378: Fix method typehint in Ewallet endpoint

### DIFF
--- a/src/Endpoints/Ewallet.php
+++ b/src/Endpoints/Ewallet.php
@@ -7,7 +7,7 @@ use EoneoPay\PhpSdk\Traits\EwalletTrait;
 use LoyaltyCorp\SdkBlueprint\Sdk\Entity;
 
 /**
- * @method mixed[]|null getBalances()
+ * @method Balance|null getBalances()
  * @method string|null getCreatedAt()
  * @method string|null getCurrency()
  * @method string|null getId()

--- a/src/Endpoints/Ewallet.php
+++ b/src/Endpoints/Ewallet.php
@@ -7,7 +7,7 @@ use EoneoPay\PhpSdk\Traits\EwalletTrait;
 use LoyaltyCorp\SdkBlueprint\Sdk\Entity;
 
 /**
- * @method Balance|null getBalances()
+ * @method Balance[]|null getBalances()
  * @method string|null getCreatedAt()
  * @method string|null getCurrency()
  * @method string|null getId()

--- a/src/Endpoints/Transactions/Allocation.php
+++ b/src/Endpoints/Transactions/Allocation.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace EoneoPay\PhpSdk\Endpoints\Transactions;
 
+use EoneoPay\PhpSdk\Endpoints\Ewallet;
 use EoneoPay\PhpSdk\Endpoints\Transactions\Allocations\Record;
 use EoneoPay\PhpSdk\Traits\Transactions\AllocationTrait;
 use LoyaltyCorp\SdkBlueprint\Sdk\Entity;

--- a/src/Endpoints/Users/ReferenceNumber.php
+++ b/src/Endpoints/Users/ReferenceNumber.php
@@ -12,9 +12,9 @@ use Symfony\Component\Serializer\Annotation\Groups;
  * @method string getReferenceNumber()
  * @method string getType()
  * @method User getUser()
- * @method setReferenceNumber(string $reference)
- * @method setType(string $type)
- * @method setUser(User $user)
+ * @method $this setReferenceNumber(string $reference)
+ * @method $this setType(string $type)
+ * @method $this setUser(User $user)
  */
 class ReferenceNumber extends Entity
 {


### PR DESCRIPTION
This PR fixes a few `@method` annotations within the below endpoints:
- Transactions/Allocation
- Users/ReferenceNumber
- Ewallet

See: https://github.com/loyaltycorp/eoneopay-phpsdk/issues/54