### PR TITLE
Fixed typehint in Ewallet endpoint

### DIFF
--- a/src/Endpoints/Ewallet.php
+++ b/src/Endpoints/Ewallet.php
@@ -7,7 +7,7 @@ use EoneoPay\PhpSdk\Traits\EwalletTrait;
 use LoyaltyCorp\SdkBlueprint\Sdk\Entity;
 
 /**
- * @method Balance|null getBalances()
+ * @method Balance|null getBalance()
  * @method string|null getCreatedAt()
  * @method string|null getCurrency()
  * @method string|null getId()

--- a/src/Endpoints/Ewallet.php
+++ b/src/Endpoints/Ewallet.php
@@ -7,7 +7,7 @@ use EoneoPay\PhpSdk\Traits\EwalletTrait;
 use LoyaltyCorp\SdkBlueprint\Sdk\Entity;
 
 /**
- * @method Balance[]|null getBalances()
+ * @method Balance|null getBalances()
  * @method string|null getCreatedAt()
  * @method string|null getCurrency()
  * @method string|null getId()

--- a/src/Traits/EwalletTrait.php
+++ b/src/Traits/EwalletTrait.php
@@ -16,7 +16,7 @@ trait EwalletTrait
      *
      * @var \EoneoPay\PhpSdk\Endpoints\Balance|null
      */
-    protected $balances;
+    protected $balance;
 
     /**
      * Created at date.

--- a/tests/Endpoints/EwalletTest.php
+++ b/tests/Endpoints/EwalletTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\EoneoPay\PhpSdk\Endpoints;
 
+use EoneoPay\PhpSdk\Endpoints\Balance;
 use EoneoPay\PhpSdk\Endpoints\Ewallet;
 use EoneoPay\PhpSdk\Endpoints\User;
 use EoneoPay\PhpSdk\Exceptions\ClientException;
@@ -21,9 +22,9 @@ final class EwalletTest extends TestCase
     public function testEwalletBalance(): void
     {
         $response = [
-            'balances' => [
-                'available' => '0.00',
-                'balance' => '0.00',
+            'balance' => [
+                'available' => '123.45',
+                'balance' => '234.56',
             ],
             'created_at' => '2019-02-25T02=>40=>32Z',
             'currency' => 'AUD',
@@ -48,9 +49,11 @@ final class EwalletTest extends TestCase
             );
 
         self::assertSame('JEKYYFZAR0', ($ewallet instanceof Ewallet) ? $ewallet->getReference() : null);
-        // check if it has balances
-        self::assertObjectHasAttribute('balances', $ewallet);
         self::assertInstanceOf(User::class, ($ewallet instanceof Ewallet) ? $ewallet->getUser() : null);
+        // check if it has balances
+        self::assertInstanceOf(Balance::class, ($ewallet instanceof Ewallet) ? $ewallet->getBalance() : null);
+        self::assertSame('123.45', ($ewallet instanceof Ewallet) ? $ewallet->getBalance()->getAvailable() : null);
+        self::assertSame('234.56', ($ewallet instanceof Ewallet) ? $ewallet->getBalance()->getBalance() : null);
     }
 
     /**

--- a/tests/Endpoints/EwalletTest.php
+++ b/tests/Endpoints/EwalletTest.php
@@ -40,6 +40,10 @@ final class EwalletTest extends TestCase
                 'updated_at' => '2019-02-22T03=>09=>44Z',
             ],
         ];
+        $expected = new Balance([
+            'available' => '123.45',
+            'balance' => '234.56',
+        ]);
 
         $ewallet = $this->createApiManager($response, 200)
             ->findOneBy(
@@ -52,8 +56,7 @@ final class EwalletTest extends TestCase
         self::assertInstanceOf(User::class, ($ewallet instanceof Ewallet) ? $ewallet->getUser() : null);
         // check if it has balances
         self::assertInstanceOf(Balance::class, ($ewallet instanceof Ewallet) ? $ewallet->getBalance() : null);
-        self::assertSame('123.45', ($ewallet instanceof Ewallet) ? $ewallet->getBalance()->getAvailable() : null);
-        self::assertSame('234.56', ($ewallet instanceof Ewallet) ? $ewallet->getBalance()->getBalance() : null);
+        self::assertEquals($expected, ($ewallet instanceof Ewallet) ? $ewallet->getBalance() : null);
     }
 
     /**


### PR DESCRIPTION
This fix involves:
- Correcting an incorrect return type in the Ewallet endpoint
- Renaming the method from `getBalances` to `getBalance`
- Updating related tests

Close your eyes, and approve.